### PR TITLE
Simplify: require binary directly, use findup

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,3 @@ Pass along any options that you would ordinarily pass directly to `eslint`, e.g.
 `eslint-closest-cli --help`
 
 `eslint-closest-cli *.js`
-
-## TODOs
-
- * Limit unecessary path traversal by using a generator-based version of
-    find-node-modules.

--- a/index.js
+++ b/index.js
@@ -1,27 +1,5 @@
 #!/usr/bin/env node
 
-const childProcess = require('child_process');
-const fs = require('fs');
-const path = require('path');
-const process = require('process');
-const findNodeModules = require('find-node-modules');
-
-const modules = findNodeModules();
-
-function getESLintPath (modulePath) {
-  return path.resolve(path.join(modulePath, '.bin', 'eslint'));
-}
-
-const nearestModulePath = modules.find((modulePath) => {
-  return fs.existsSync(getESLintPath(modulePath));
-});
-
-const args = process.argv.slice(2);
-
-const eslintPath = nearestModulePath ? getESLintPath(nearestModulePath) : 'eslint';
-
-childProcess.spawn(eslintPath, args, {
-  cwd: process.cwd,
-  env: process.env,
-  stdio: 'inherit'
-});
+const findup = require('findup-sync');
+const eslintPath = findup('node_modules/.bin/eslint') || 'eslint';
+require(eslintPath);

--- a/package.json
+++ b/package.json
@@ -1,17 +1,23 @@
 {
   "name": "eslint-closest-cli",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Finds the ESLint CLI closest to the current working directory and wraps it",
-  "keywords": ["eslint", "nearest", "closest", "cli", "cwd"],
+  "keywords": [
+    "eslint",
+    "nearest",
+    "closest",
+    "cli",
+    "cwd"
+  ],
   "main": "index.js",
-  "bin": "index.js", 
+  "bin": "index.js",
   "author": "Ben Regenspan",
   "license": "ISC",
   "repository": {
     "type": "git",
-    "url" : "https://github.com/bregenspan/eslint-closest-cli.git"
+    "url": "https://github.com/bregenspan/eslint-closest-cli.git"
   },
   "dependencies": {
-    "find-node-modules": "^1.0.4"
+    "findup-sync": "^2.0.0"
   }
 }


### PR DESCRIPTION
This code is obviously a lot simpler. It should perform better in cases with a deeply-nested folder structure, and removes the (tiny) extra overhead involved in launching a child process.